### PR TITLE
Add example configs for 10.10.10 helper network

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@
    git clone https://github.com/ryanhay/ocp4-metal-install
    ```
 
+   If your helper node uses the `10.10.10.0/24` network instead of the default
+   `192.168.22.0/24`, copy the files in `examples/custom-10.10.10` from the
+   cloned repository and use them in place of the default configuration files.
+
 1. OPTIONAL: Create a file '~/.vimrc' and paste the following (this helps with editing in vim, particularly yaml files):
 
    ```bash

--- a/examples/custom-10.10.10/dhcpd.conf
+++ b/examples/custom-10.10.10/dhcpd.conf
@@ -1,0 +1,46 @@
+authoritative;
+ddns-update-style interim;
+allow booting;
+allow bootp;
+allow unknown-clients;
+ignore client-updates;
+default-lease-time 14400;
+max-lease-time 14400;
+
+subnet 10.10.10.0 netmask 255.255.255.0 {
+ option routers                  10.10.10.1; # lan
+ option subnet-mask              255.255.255.0;
+ option domain-name              "ocp.lan";
+ option domain-name-servers       10.10.10.1;
+ range 10.10.10.80 10.10.10.99;
+}
+
+host ocp-bootstrap {
+ hardware ethernet 00:0c:29:83:df:be;
+ fixed-address 10.10.10.200;
+}
+
+host ocp-cp-1 {
+ hardware ethernet 00:0c:29:65:d5:0f;
+ fixed-address 10.10.10.201;
+}
+
+host ocp-cp-2 {
+ hardware ethernet 00:0c:29:8e:91:c2;
+ fixed-address 10.10.10.202;
+}
+
+host ocp-cp-3 {
+ hardware ethernet 00:0c:29:4e:e6:77;
+ fixed-address 10.10.10.203;
+}
+
+host ocp-w-1 {
+ hardware ethernet 00:0c:29:da:35:11;
+ fixed-address 10.10.10.211;
+}
+
+host ocp-w-2 {
+ hardware ethernet 00:0c:29:3d:ea:c4;
+ fixed-address 10.10.10.212;
+}

--- a/examples/custom-10.10.10/dns/named.conf
+++ b/examples/custom-10.10.10/dns/named.conf
@@ -1,0 +1,78 @@
+//
+// named.conf
+//
+// Provided by Red Hat bind package to configure the ISC BIND named(8) DNS
+// server as a caching only nameserver (as a localhost DNS resolver only).
+//
+// See /usr/share/doc/bind*/sample/ for example named configuration files.
+//
+// See the BIND Administrator's Reference Manual (ARM) for details about the
+// configuration located in /usr/share/doc/bind-{version}/Bv9ARM.html
+
+options {
+	listen-on port 53 { 127.0.0.1; 10.10.10.1; };
+#	listen-on-v6 port 53 { ::1; };
+	directory 	"/var/named";
+	dump-file 	"/var/named/data/cache_dump.db";
+	statistics-file "/var/named/data/named_stats.txt";
+	memstatistics-file "/var/named/data/named_mem_stats.txt";
+	recursing-file  "/var/named/data/named.recursing";
+	secroots-file   "/var/named/data/named.secroots";
+	allow-query     { localhost; 10.10.10.0/24; };
+
+	/*
+	 - If you are building an AUTHORITATIVE DNS server, do NOT enable recursion.
+	 - If you are building a RECURSIVE (caching) DNS server, you need to enable
+	   recursion.
+	 - If your recursive DNS server has a public IP address, you MUST enable access
+	   control to limit queries to your legitimate users. Failing to do so will
+	   cause your server to become part of large scale DNS amplification
+	   attacks. Implementing BCP38 within your network would greatly
+	   reduce such attack surface
+	*/
+	recursion yes;
+
+	dnssec-enable yes;
+	dnssec-validation yes;
+
+	# Using Google DNS
+	forwarders {
+                8.8.8.8;
+                8.8.4.4;
+        };
+
+	/* Path to ISC DLV key */
+	bindkeys-file "/etc/named.root.key";
+
+	managed-keys-directory "/var/named/dynamic";
+
+	pid-file "/run/named/named.pid";
+	session-keyfile "/run/named/session.key";
+};
+
+logging {
+        channel default_debug {
+                file "data/named.run";
+                severity dynamic;
+        };
+};
+
+zone "." IN {
+	type hint;
+	file "named.ca";
+};
+
+# Include ocp zones
+
+zone "ocp.lan" {
+    type master;
+    file "/etc/named/zones/db.ocp.lan"; # zone file path
+};
+
+zone "10.10.10.in-addr.arpa" {
+    type master;
+    file "/etc/named/zones/db.reverse";  # 10.10.10.0/24 subnet
+};
+
+include "/etc/named.rfc1912.zones";
+include "/etc/named.root.key";

--- a/examples/custom-10.10.10/dns/zones/db.ocp.lan
+++ b/examples/custom-10.10.10/dns/zones/db.ocp.lan
@@ -1,0 +1,41 @@
+$TTL    604800
+@       IN      SOA     ocp-svc.ocp.lan. contact.ocp.lan (
+                  1     ; Serial
+             604800     ; Refresh
+              86400     ; Retry
+            2419200     ; Expire
+             604800     ; Minimum
+)
+        IN      NS      ocp-svc
+
+ocp-svc.ocp.lan.          IN      A       10.10.10.1
+
+; Temp Bootstrap Node
+ocp-bootstrap.lab.ocp.lan.        IN      A      10.10.10.200
+
+; Control Plane Nodes
+ocp-cp-1.lab.ocp.lan.         IN      A      10.10.10.201
+ocp-cp-2.lab.ocp.lan.         IN      A      10.10.10.202
+ocp-cp-3.lab.ocp.lan.         IN      A      10.10.10.203
+
+; Worker Nodes
+ocp-w-1.lab.ocp.lan.        IN      A      10.10.10.211
+ocp-w-2.lab.ocp.lan.        IN      A      10.10.10.212
+
+; OpenShift Internal - Load balancer
+api.lab.ocp.lan.        IN    A    10.10.10.1
+api-int.lab.ocp.lan.    IN    A    10.10.10.1
+*.apps.lab.ocp.lan.     IN    A    10.10.10.1
+
+; ETCD Cluster
+etcd-0.lab.ocp.lan.    IN    A     10.10.10.201
+etcd-1.lab.ocp.lan.    IN    A     10.10.10.202
+etcd-2.lab.ocp.lan.    IN    A     10.10.10.203
+
+; OpenShift Internal SRV records (cluster name = lab)
+_etcd-server-ssl._tcp.lab.ocp.lan.    86400     IN    SRV     0    10    2380    etcd-0.lab
+_etcd-server-ssl._tcp.lab.ocp.lan.    86400     IN    SRV     0    10    2380    etcd-1.lab
+_etcd-server-ssl._tcp.lab.ocp.lan.    86400     IN    SRV     0    10    2380    etcd-2.lab
+
+oauth-openshift.apps.lab.ocp.lan.     IN     A     10.10.10.1
+console-openshift-console.apps.lab.ocp.lan.     IN     A     10.10.10.1

--- a/examples/custom-10.10.10/dns/zones/db.reverse
+++ b/examples/custom-10.10.10/dns/zones/db.reverse
@@ -1,0 +1,23 @@
+$TTL    604800
+@       IN      SOA     ocp-svc.ocp.lan. contact.ocp.lan (
+                  1     ; Serial
+             604800     ; Refresh
+              86400     ; Retry
+            2419200     ; Expire
+             604800     ; Minimum
+)
+
+  IN      NS      ocp-svc.ocp.lan.
+
+1      IN    PTR    ocp-svc.ocp.lan.
+1      IN    PTR    api.lab.ocp.lan.
+1      IN    PTR    api-int.lab.ocp.lan.
+;
+200    IN    PTR    ocp-bootstrap.lab.ocp.lan.
+;
+201    IN    PTR    ocp-cp-1.lab.ocp.lan.
+202    IN    PTR    ocp-cp-2.lab.ocp.lan.
+203    IN    PTR    ocp-cp-3.lab.ocp.lan.
+;
+211    IN    PTR    ocp-w-1.lab.ocp.lan.
+212    IN    PTR    ocp-w-2.lab.ocp.lan.

--- a/examples/custom-10.10.10/haproxy.cfg
+++ b/examples/custom-10.10.10/haproxy.cfg
@@ -1,0 +1,92 @@
+# Global settings
+#---------------------------------------------------------------------
+global
+    maxconn     20000
+    log         /dev/log local0 info
+    chroot      /var/lib/haproxy
+    pidfile     /var/run/haproxy.pid
+    user        haproxy
+    group       haproxy
+    daemon
+
+    # turn on stats unix socket
+    stats socket /var/lib/haproxy/stats
+
+#---------------------------------------------------------------------
+# common defaults that all the 'listen' and 'backend' sections will
+# use if not designated in their block
+#---------------------------------------------------------------------
+defaults
+    log                     global
+    mode                    http
+    option                  httplog
+    option                  dontlognull
+    option http-server-close
+    option redispatch
+    option forwardfor       except 127.0.0.0/8
+    retries                 3
+    maxconn                 20000
+    timeout http-request    10000ms
+    timeout http-keep-alive 10000ms
+    timeout check           10000ms
+    timeout connect         40000ms
+    timeout client          300000ms
+    timeout server          300000ms
+    timeout queue           50000ms
+
+# Enable HAProxy stats
+listen stats
+    bind :9000
+    stats uri /stats
+    stats refresh 10000ms
+
+# Kube API Server
+frontend k8s_api_frontend
+    bind :6443
+    default_backend k8s_api_backend
+    mode tcp
+
+backend k8s_api_backend
+    mode tcp
+    balance source
+    server      ocp-bootstrap 10.10.10.200:6443 check
+    server      ocp-cp-1 10.10.10.201:6443 check
+    server      ocp-cp-2 10.10.10.202:6443 check
+    server      ocp-cp-3 10.10.10.203:6443 check
+
+# OCP Machine Config Server
+frontend ocp_machine_config_server_frontend
+    mode tcp
+    bind :22623
+    default_backend ocp_machine_config_server_backend
+
+backend ocp_machine_config_server_backend
+    mode tcp
+    balance source
+    server      ocp-bootstrap 10.10.10.200:22623 check
+    server      ocp-cp-1 10.10.10.201:22623 check
+    server      ocp-cp-2 10.10.10.202:22623 check
+    server      ocp-cp-3 10.10.10.203:22623 check
+
+# OCP Ingress - layer 4 tcp mode for each. Ingress Controller will handle layer 7.
+frontend ocp_http_ingress_frontend
+    bind :80
+    default_backend ocp_http_ingress_backend
+    mode tcp
+
+backend ocp_http_ingress_backend
+    balance source
+    mode tcp
+    server      ocp-w-1 10.10.10.211:80 check
+    server      ocp-w-2 10.10.10.212:80 check
+
+frontend ocp_https_ingress_frontend
+    bind *:443
+    default_backend ocp_https_ingress_backend
+    mode tcp
+
+backend ocp_https_ingress_backend
+    mode tcp
+    balance source
+    server      ocp-w-1 10.10.10.211:443 check
+    server      ocp-w-2 10.10.10.212:443 check

--- a/examples/custom-10.10.10/install-config.yaml
+++ b/examples/custom-10.10.10/install-config.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+baseDomain: ocp.lan
+compute:
+  - hyperthreading: Enabled
+    name: worker
+    replicas: 0 # Must be set to 0 for User Provisioned Installation as worker nodes will be manually deployed.
+controlPlane:
+  hyperthreading: Enabled
+  name: master
+  replicas: 3
+metadata:
+  name: lab # Cluster name
+networking:
+  clusterNetwork:
+    - cidr: 10.128.0.0/14
+      hostPrefix: 23
+  networkType: OpenShiftSDN
+  serviceNetwork:
+    - 172.30.0.0/16
+platform:
+  none: {}
+fips: false
+pullSecret: '{"auths": ...}'
+sshKey: "ssh-ed25519 AAAA..."

--- a/examples/custom-10.10.10/manifest/registry-pv.yaml
+++ b/examples/custom-10.10.10/manifest/registry-pv.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: registry-pv
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: 100Gi
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    path: /shares/registry
+    server: 10.10.10.1


### PR DESCRIPTION
## Summary
- include configuration examples for helper nodes on the 10.10.10.0/24 network
- document where to find the alternate configs in README

## Testing
- `git status --short`